### PR TITLE
Fixed argument parsing for --compile option.

### DIFF
--- a/midicomp.c
+++ b/midicomp.c
@@ -113,16 +113,20 @@ int main(int argc, char **argv) {
     char *outfile;
 
     if (optind < argc) {
-      yyin = efopen (argv[optind], "r");
-      infile = argv[optind];
+      if (optind+1 < argc) {
+        yyin = efopen(argv[optind], "r");
+        infile = argv[optind];
+        F = efopen(argv[optind+1], "wb");
+        outfile = argv[optind+1];
+      } else {
+        yyin = stdin;
+        infile = "stdin";
+        F = efopen(argv[optind], "wb");
+        outfile = argv[optind];
+      }
     } else {
       yyin = stdin;
       infile = "stdin";
-    }
-    if (optind+1 < argc ) {
-      F = efopen(argv[optind+1], "wb");
-      outfile = argv[optind+1];
-    } else {
 #ifdef SETMODE
       setmode (fileno(stdout), O_BINARY);
       F = stdout;


### PR DESCRIPTION
From the README:

    midicomp -c some.mid < some.asc     # input from stdin with one arg

Before this change, the program was trying to use the given argument as *input* and stdout as output.
After this change, it works as documented: the program reads from stdin and *writes* to the given filename.

By the way, thanks for sharing this tool. It's very useful!
